### PR TITLE
Use HTTP for Submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "deps/lexy"]
 	path = deps/lexy
-	url = git@github.com:foonathan/lexy.git
+	url = https://github.com/foonathan/lexy
 	ignore = dirty
 [submodule "scripts"]
 	path = scripts
-	url = git@github.com:OpenVicProject/scripts
+	url = https://github.com/OpenVicProject/scripts


### PR DESCRIPTION
Previously unable to build without SSH, useful on Windows.