### PR TITLE
Limit .gitignore of build directory to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,4 @@ bin/*
 /compile_commands.json
 
 # Out-of-source build directory
-build/
+/build/


### PR DESCRIPTION
VSCode uses .gitignore to hide directories, without this change this includes `scripts/build`, making it impossible to open or search the directory inside VSCode.